### PR TITLE
feat: GitHub SARIF

### DIFF
--- a/.github/workflows/runexamples.yml
+++ b/.github/workflows/runexamples.yml
@@ -20,6 +20,7 @@ jobs:
       uses: ./
       with:
         binary-path: 'Examples'
+        github-sarif: 'true'
 
     - name: Infer# analysis results
       run: cat infer-out/report.txt
@@ -28,7 +29,7 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: report
-        path: infer-out/report.txt
+        path: infer-out/report.*
     
     - name: Upload SARIF output to GitHub Security Center
       uses: github/codeql-action/upload-sarif@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/infersharp:v1.4
+FROM mcr.microsoft.com/infersharp:v1.5
 
 ADD run_infersharp_ci.sh /run_infersharp_ci.sh
 COPY entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM mcr.microsoft.com/infersharp:v1.4
 
+ADD run_infersharp_ci.sh /run_infersharp_ci.sh
 COPY entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,10 @@ inputs:
   optional-flags:
     description: 'Optional flags, see https://fbinfer.com/docs/man-infer-run/#OPTIONS for the complete list.'
     required: false
+  github-sarif:
+    description: 'If set true automaticaly address issue https://github.com/microsoft/infersharpaction/issues/51 and trasform absolute path in relative.'
+    required: false
+    default: 'false'
 outputs:
   results:
     description: 'The analysis results'
@@ -18,4 +22,5 @@ runs:
   image: 'Dockerfile'
   args:
     - ${{ inputs.binary-path }}
+    - ${{ inputs.github-sarif }}
     - ${{ inputs.optional-flags }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,7 +8,7 @@ SCRIPTPATH=$(dirname "$SCRIPT")
 FULLPATH=$(readlink -f "$1") 
 
 # Downlaod infersharp config
-curl -o $SCRIPTPATH/.inferconfig https://raw.githubusercontent.com/microsoft/infersharp/v1.4/.inferconfig
+curl -o $SCRIPTPATH/.inferconfig https://raw.githubusercontent.com/microsoft/infersharp/v1.5/.inferconfig
 
 # Add execution auth
 chmod +x $SCRIPTPATH/run_infersharp_ci.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,8 +2,16 @@
 
 set -e
 
-curl -o run_infersharp.sh https://raw.githubusercontent.com/microsoft/infersharpaction/v1.4/run_infersharp_ci.sh
-curl -o .inferconfig https://raw.githubusercontent.com/microsoft/infersharp/v1.4/.inferconfig
-chmod +x run_infersharp.sh
-chmod +x .inferconfig
-./run_infersharp.sh "$1" $2
+# transform binary-path from relative tu absolute
+SCRIPT=$(realpath -s "$0")
+SCRIPTPATH=$(dirname "$SCRIPT")
+FULLPATH=$(readlink -f "$1") 
+
+# Downlaod infersharp config
+curl -o $SCRIPTPATH/.inferconfig https://raw.githubusercontent.com/microsoft/infersharp/v1.4/.inferconfig
+
+# Add execution auth
+chmod +x $SCRIPTPATH/run_infersharp_ci.sh
+chmod +x $SCRIPTPATH/.inferconfig
+
+$SCRIPTPATH/run_infersharp_ci.sh "$FULLPATH" $2 $3

--- a/run_infersharp_ci.sh
+++ b/run_infersharp_ci.sh
@@ -5,16 +5,18 @@
 
 set -e
 
+github_sarif=$2
+
 # Check if we have enough arguments.
-if [ "$#" -lt 1 ]; then
+if [ "$#" -lt 2 ]; then
     echo "run_infersharp.sh <dll_folder_path> <options - see https://fbinfer.com/docs/man-infer-run#OPTIONS>"
-	exit
+	exit 1
 fi
 
 infer_args=""
 
-if [ "$#" -gt 1 ]; then
-    i=2
+if [ "$#" -gt 2 ]; then
+    i=3
     while [ $i -le $# ]
     do 		
         if [ ${!i} == "--output-folder" ]; then
@@ -26,6 +28,12 @@ if [ "$#" -gt 1 ]; then
         ((i++))
     done
 fi
+
+if [ "$output_folder" == "" ]; then
+    output_folder="$PWD/infer-out"
+fi
+
+echo -e "Output folder $output_folder"
 
 echo "Processing {$1}"
 # Preparation
@@ -41,6 +49,26 @@ echo -e "Code translation started..."
 /./infersharp/Cilsil/Cilsil translate infer-staging --outcfg infer-staging/cfg.json --outtenv infer-staging/tenv.json --cfgtxt infer-staging/cfg.txt --extprogress
 echo -e "Code translation completed. Analyzing...\n"
 infer run $infer_args --cfg-json infer-staging/cfg.json --tenv-json infer-staging/tenv.json
+
+if [ ${github_sarif,,} == 'true' ]; then
+    
+    # Create backup
+    cp infer-out/report.sarif infer-out/report.sarif.bak
+
+    # fix https://github.com/microsoft/infersharpaction/issues/51
+    sed -i 's/\"startColumn\":0/\"startColumn\":1/g' infer-out/report.sarif
+
+    # replace sourcelink root _ path with ``
+    sed -i 's/\"uri\":\"file:_\//\"uri\":\"/g' infer-out/report.sarif
+    
+    # replace file:home/runner/work/$GITHUB_REPOSITORY_NAME/$GITHUB_REPOSITORY_NAME/ path with ''
+    prefix="$GITHUB_REPOSITORY_OWNER/"
+    GITHUB_REPOSITORY_NAME=${GITHUB_REPOSITORY#"$prefix"}
+    echo "$GITHUB_REPOSITORY_OWNER"
+    echo "$GITHUB_REPOSITORY_NAME"
+    command="s/\"uri\":\"file:home\/runner\/work\/$GITHUB_REPOSITORY_NAME\/$GITHUB_REPOSITORY_NAME\//\"uri\":\"/g"
+    sed -i $command infer-out/report.sarif
+fi
 
 if [ "$output_folder" != "" ]; then
     if [ ! -d "$output_folder" ]; then


### PR DESCRIPTION
fixes #51

Added github-sarif option to GitHub Action, disabled by default. This option fixes some compatibility issues with GitHub Code Security.
 
If  github-sarif is true:

- Replace `"startLine": 0` with `"startLine": 1`
- Transform absolute path to relative
     - replace `"uri": "file:_/` with `"uri": "`
     - replace `"uri": "/home/runner/work/infersharpaction/infersharpaction/` with `"uri": "`


